### PR TITLE
Fix logic for ravel_1D orbit direction time offset

### DIFF
--- a/gcpy/raveller_1D.py
+++ b/gcpy/raveller_1D.py
@@ -40,8 +40,8 @@ def create_track_func(args):
     #(ds['latitude'] / 180) * args.vertical_scan_time) % 24
     # vary overpass time with latitude
     overpass_offset = ds['latitude'] / 90 * 24 / args.orbits_per_day / 4 * 60
-    if args.direction == 'ascending':
-        # overpass delayed at high northern latitudes if ascending
+    if args.direction == 'descending':
+        # overpass advanced at high northern latitudes if descending
         overpass_offset = -overpass_offset
 
     longitude = ds.longitude.values


### PR DESCRIPTION
### Name and Institution (Required)

Name: Yuanjian Zhang
Institution: WashU

### Describe the update

Fix the logic of ravel_1D program that creates orbit file for 1D GCHP diagnostic

Overpassing time advanced (negative offset) at northern latitudes and delayed (positive offset) at southern latitudes if descending. So time offset needs to be inversed for descending but not ascending.
